### PR TITLE
fix: update commons crypto version to 2.5.0

### DIFF
--- a/utils/crypto/pom.xml
+++ b/utils/crypto/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>selc-common-utils</artifactId>
         <groupId>it.pagopa.selfcare</groupId>
-        <version>2.4.9</version>
+        <version>2.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
#### List of Changes

Update commons crypto version to 2.5.0

#### Motivation and Context

This change is necessary to build other microservices using commons version 2.5.0