### PR TITLE
[SELC-6486] upgrade version of actions/cache to v.4.2.0

### DIFF
--- a/.github/workflows/call_release_docker.yml
+++ b/.github/workflows/call_release_docker.yml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Retrieve Terraform Modules from Cache
         id: cache-terraform-modules
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ inputs.dir }}/.terraform
           key: terraform-${{ inputs.dir }}-${{ github.sha }}


### PR DESCRIPTION
#### List of Changes

- Changed version of actions/cache in call_release_docker.yml workflow

#### Motivation and Context

[version used is deprecated
](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down)

#### Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/468efb68-5e48-4a5c-be27-c0bd37a75a45)

#### Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.