### PR TITLE
[SELC-7545] feat: Adding new Pagopa jwt issuer Authenticator

### DIFF
--- a/base/pom.xml
+++ b/base/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>selc-commons</artifactId>
         <groupId>it.pagopa.selfcare</groupId>
-        <version>2.8.6</version>
+        <version>2.9.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>selc-commons</artifactId>
         <groupId>it.pagopa.selfcare</groupId>
-        <version>2.8.6</version>
+        <version>2.9.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/connector/rest/pom.xml
+++ b/connector/rest/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>selc-commons-connector</artifactId>
         <groupId>it.pagopa.selfcare</groupId>
-        <version>2.8.6</version>
+        <version>2.9.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/connector/soap/aruba-sign/pom.xml
+++ b/connector/soap/aruba-sign/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>selc-commons-connector-soap</artifactId>
         <groupId>it.pagopa.selfcare</groupId>
-        <version>2.8.6</version>
+        <version>2.9.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/connector/soap/pom.xml
+++ b/connector/soap/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>selc-commons-connector</artifactId>
         <groupId>it.pagopa.selfcare</groupId>
-        <version>2.8.6</version>
+        <version>2.9.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/connector/soap/utils/pom.xml
+++ b/connector/soap/utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>selc-commons-connector-soap</artifactId>
         <groupId>it.pagopa.selfcare</groupId>
-        <version>2.8.6</version>
+        <version>2.9.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     </parent>
 
     <artifactId>selc-commons</artifactId>
-    <version>2.8.6</version>
+    <version>2.9.0</version>
     <name>selc-commons</name>
     <description>Self Care Commons</description>
 
@@ -26,29 +26,29 @@
             <dependency>
                 <groupId>it.pagopa.selfcare</groupId>
                 <artifactId>selc-commons-base</artifactId>
-                <version>2.8.6</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>it.pagopa.selfcare</groupId>
                 <artifactId>selc-commons-base</artifactId>
-                <version>2.8.6</version>
+                <version>2.9.0</version>
                 <type>test-jar</type>
             </dependency>
             <dependency>
                 <groupId>it.pagopa.selfcare.utils</groupId>
                 <artifactId>selc-commons-crypto</artifactId>
-                <version>2.8.6</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>it.pagopa.selfcare.utils</groupId>
                 <artifactId>selc-commons-crypto</artifactId>
-                <version>2.8.6</version>
+                <version>2.9.0</version>
                 <type>test-jar</type>
             </dependency>
             <dependency>
                 <groupId>it.pagopa.selfcare.soap</groupId>
                 <artifactId>selc-commons-connector-soap-utils</artifactId>
-                <version>2.8.6</version>
+                <version>2.9.0</version>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback.contrib</groupId>

--- a/utils/crypto/pom.xml
+++ b/utils/crypto/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>selc-common-utils</artifactId>
     <groupId>it.pagopa.selfcare</groupId>
-    <version>2.8.6</version>
+    <version>2.9.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>selc-commons</artifactId>
         <groupId>it.pagopa.selfcare</groupId>
-        <version>2.8.6</version>
+        <version>2.9.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>selc-commons</artifactId>
     <groupId>it.pagopa.selfcare</groupId>
-    <version>2.8.6</version>
+    <version>2.9.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/web/src/main/java/it/pagopa/selfcare/commons/web/security/JwtAuthenticationStrategyFactoryImpl.java
+++ b/web/src/main/java/it/pagopa/selfcare/commons/web/security/JwtAuthenticationStrategyFactoryImpl.java
@@ -86,6 +86,7 @@ public class JwtAuthenticationStrategyFactoryImpl implements JwtAuthenticationSt
       case "SPID" -> beanFactory.getBean(SpidJwtAuthenticationStrategy.class);
       case "kubernetes/serviceaccount" ->
         beanFactory.getBean(K8sJwtAuthenticationStrategy.class);
+      case "PAGOPA" -> beanFactory.getBean(PagopaJwtAuthenticationStrategy.class);
       default -> throw new IllegalArgumentException("Unknown issuer");
     };
     return bean;

--- a/web/src/main/java/it/pagopa/selfcare/commons/web/security/PagopaJwtAuthenticationStrategy.java
+++ b/web/src/main/java/it/pagopa/selfcare/commons/web/security/PagopaJwtAuthenticationStrategy.java
@@ -1,0 +1,75 @@
+package it.pagopa.selfcare.commons.web.security;
+
+import io.jsonwebtoken.Claims;
+import it.pagopa.selfcare.commons.base.logging.LogUtils;
+import it.pagopa.selfcare.commons.base.security.SelfCareUser;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * Implementation of {@link JwtAuthenticationStrategy} based on SPID JWT
+ */
+@Slf4j
+@Service
+public class PagopaJwtAuthenticationStrategy implements JwtAuthenticationStrategy {
+
+    private static final String MDC_UID = "uid";
+    private static final String CLAIMS_UID = "uid";
+//    private static final String CLAIM_EMAIL = "email";
+
+    private final JwtService jwtService;
+    private final AuthoritiesRetriever authoritiesRetriever;
+
+
+    @Autowired
+    public PagopaJwtAuthenticationStrategy(JwtService jwtService, AuthoritiesRetriever authoritiesRetriever) {
+        log.trace("Initializing {}", PagopaJwtAuthenticationStrategy.class.getSimpleName());
+        this.jwtService = jwtService;
+        this.authoritiesRetriever = authoritiesRetriever;
+    }
+
+
+    @Override
+    public JwtAuthenticationToken authenticate(JwtAuthenticationToken authentication) throws AuthenticationException {
+        log.trace("authenticate start");
+        log.debug(LogUtils.CONFIDENTIAL_MARKER, "authenticate authentication = {}", authentication);
+
+        SelfCareUser user;
+        try {
+            Claims claims = jwtService.getClaims(authentication.getCredentials());
+            log.debug(LogUtils.CONFIDENTIAL_MARKER, "authenticate user with id = {}", claims.get(CLAIMS_UID, String.class));
+            Optional<String> uid = Optional.ofNullable(claims.get(CLAIMS_UID, String.class));
+            uid.ifPresentOrElse(value -> MDC.put(MDC_UID, value),
+                    () -> log.warn("uid claims is null"));
+
+            user = SelfCareUser.builder(uid.orElse("uid_not_provided"))
+//                    .email(claims.get(CLAIM_EMAIL, String.class))
+                    .build();
+
+        } catch (Exception e) {
+            MDC.remove(MDC_UID);
+            throw new JwtAuthenticationException(e.getMessage(), e);
+        }
+
+        final Collection<GrantedAuthority> authorities;
+        try {
+            authorities = authoritiesRetriever.retrieveAuthorities();
+        } catch (Exception e) {
+            throw new AuthoritiesRetrieverException("An error occurred during authorities retrieval", e);
+        }
+        JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(authentication.getCredentials(),
+                user,
+                authorities);
+
+        log.trace("authenticate end");
+        return authenticationToken;
+    }
+
+}

--- a/web/src/test/java/it/pagopa/selfcare/commons/web/security/JwtAuthenticationStrategyFactoryImplTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/commons/web/security/JwtAuthenticationStrategyFactoryImplTest.java
@@ -42,6 +42,8 @@ class JwtAuthenticationStrategyFactoryImplTest {
                         jwtAuthenticationStrategy = mock(SpidJwtAuthenticationStrategy.class);
                     } else if (K8sJwtAuthenticationStrategy.class.equals(argument)) {
                         jwtAuthenticationStrategy = mock(K8sJwtAuthenticationStrategy.class);
+                    } else if (PagopaJwtAuthenticationStrategy.class.equals(argument)) {
+                      jwtAuthenticationStrategy = mock(PagopaJwtAuthenticationStrategy.class);
                     } else {
                         jwtAuthenticationStrategy = null;
                     }
@@ -83,7 +85,8 @@ class JwtAuthenticationStrategyFactoryImplTest {
     private static Stream<Arguments> getJwtAuthenticationStrategyArgumentsProvider() {
         return Stream.of(
                 Arguments.of(SpidJwtAuthenticationStrategy.class, "SPID"),
-                Arguments.of(K8sJwtAuthenticationStrategy.class, "kubernetes/serviceaccount")
+                Arguments.of(K8sJwtAuthenticationStrategy.class, "kubernetes/serviceaccount"),
+                Arguments.of(PagopaJwtAuthenticationStrategy.class, "PAGOPA")
         );
     }
 

--- a/web/src/test/java/it/pagopa/selfcare/commons/web/security/PagopaJwtAuthenticationStrategyTest.java
+++ b/web/src/test/java/it/pagopa/selfcare/commons/web/security/PagopaJwtAuthenticationStrategyTest.java
@@ -1,0 +1,160 @@
+package it.pagopa.selfcare.commons.web.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.impl.DefaultClaims;
+import it.pagopa.selfcare.commons.base.security.SelfCareUser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith({MockitoExtension.class})
+class PagopaJwtAuthenticationStrategyTest {
+
+    private static final String MDC_UID = "uid";
+    private static final String CLAIM_UID = "uid";
+//    private static final String CLAIM_EMAIL = "email";
+
+    @InjectMocks
+    private PagopaJwtAuthenticationStrategy pagopaJwtAuthenticationStrategy;
+
+    @Mock
+    private JwtService jwtServiceMock;
+
+    @Mock
+    private AuthoritiesRetriever authoritiesRetrieverMock;
+
+
+    @AfterEach
+    void cleanUp() {
+        MDC.clear();
+    }
+
+
+    @Test
+    void authenticate_nullAuth() {
+        // given
+        JwtAuthenticationToken authentication = null;
+        // when
+        Executable executable = () -> pagopaJwtAuthenticationStrategy.authenticate(authentication);
+        // then
+        assertThrows(RuntimeException.class, executable);
+        verifyNoInteractions(jwtServiceMock, authoritiesRetrieverMock);
+    }
+
+
+    @Test
+    void authenticate_invalidToken() {
+        // given
+        String token = "token";
+        JwtAuthenticationToken authentication = new JwtAuthenticationToken(token);
+        doThrow(RuntimeException.class)
+                .when(jwtServiceMock)
+                .getClaims(Mockito.any());
+        // when
+        Executable executable = () -> pagopaJwtAuthenticationStrategy.authenticate(authentication);
+        // then
+        assertThrows(JwtAuthenticationException.class, executable);
+        assertNull(MDC.get(MDC_UID));
+        verify(jwtServiceMock, times(1))
+                .getClaims(token);
+        verifyNoMoreInteractions(jwtServiceMock);
+        verifyNoInteractions(authoritiesRetrieverMock);
+    }
+
+
+    @Test
+    void authenticate_koAuthoritiesRetriever() {
+        // given
+        String token = "token";
+        JwtAuthenticationToken authentication = new JwtAuthenticationToken(token);
+        when(jwtServiceMock.getClaims(any()))
+                .thenReturn(mock(Claims.class));
+        doThrow(RuntimeException.class)
+                .when(authoritiesRetrieverMock)
+                .retrieveAuthorities();
+        // when
+        Executable executable = () -> pagopaJwtAuthenticationStrategy.authenticate(authentication);
+        // then
+        assertThrows(AuthoritiesRetrieverException.class, executable);
+        assertNull(MDC.get(MDC_UID));
+        verify(jwtServiceMock, times(1))
+                .getClaims(token);
+        verify(authoritiesRetrieverMock, times(1))
+                .retrieveAuthorities();
+        verifyNoMoreInteractions(jwtServiceMock, authoritiesRetrieverMock);
+    }
+
+
+    @Test
+    void authenticate_nullUidAndNullAuthorities() {
+        // given
+        String token = "token";
+        JwtAuthenticationToken authentication = new JwtAuthenticationToken(token);
+        when(jwtServiceMock.getClaims(any()))
+                .thenReturn(mock(Claims.class));
+        // when
+        Authentication authenticate = pagopaJwtAuthenticationStrategy.authenticate(authentication);
+        // then
+        assertNull(MDC.get(MDC_UID));
+        assertNotNull(authenticate);
+        assertEquals(token, authenticate.getCredentials());
+        assertEquals(SelfCareUser.class, authenticate.getPrincipal().getClass());
+        assertEquals("uid_not_provided", ((SelfCareUser) authenticate.getPrincipal()).getId());
+        assertNotNull(authenticate.getAuthorities());
+        assertTrue(authenticate.getAuthorities().isEmpty());
+        verify(jwtServiceMock, times(1))
+                .getClaims(token);
+        verify(authoritiesRetrieverMock, times(1))
+                .retrieveAuthorities();
+        verifyNoMoreInteractions(jwtServiceMock, authoritiesRetrieverMock);
+    }
+
+
+    @Test
+    void authenticate() {
+        // given
+        String token = "token";
+        JwtAuthenticationToken authentication = new JwtAuthenticationToken(token);
+        String uid = "uid";
+        String email = "email@prova.com";
+        String fiscalCode = "fiscalCode";
+        when(jwtServiceMock.getClaims(any()))
+                .thenReturn(new DefaultClaims(Map.of(CLAIM_UID, uid))); //, CLAIM_EMAIL, email
+        String role = "role";
+        when(authoritiesRetrieverMock.retrieveAuthorities())
+                .thenReturn(List.of(new SimpleGrantedAuthority(role), new SimpleGrantedAuthority(role), new SimpleGrantedAuthority(role)));
+        // when
+        Authentication authenticate = pagopaJwtAuthenticationStrategy.authenticate(authentication);
+        // then
+        assertEquals(uid, MDC.get(MDC_UID));
+        assertNotNull(authenticate);
+        assertEquals(token, authenticate.getCredentials());
+        assertEquals(SelfCareUser.class, authenticate.getPrincipal().getClass());
+        assertEquals(uid, ((SelfCareUser) authenticate.getPrincipal()).getId());
+//        assertEquals(email, ((SelfCareUser) authenticate.getPrincipal()).getEmail());
+        assertNotNull(authenticate.getAuthorities());
+        assertEquals(3, authenticate.getAuthorities().size());
+        authenticate.getAuthorities().forEach(grantedAuthority -> assertEquals(role, grantedAuthority.getAuthority()));
+        verify(jwtServiceMock, times(1))
+                .getClaims(token);
+        verify(authoritiesRetrieverMock, times(1))
+                .retrieveAuthorities();
+        verifyNoMoreInteractions(jwtServiceMock, authoritiesRetrieverMock);
+    }
+
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
- Added a new configuration option to specify the PagoPA JWT issuer URL.
- Implemented a new authenticator class that validates tokens signed by the PagoPA issuer.
- Updated the authentication filter to select the correct authenticator based on the token's issuer.
<!--- Describe your changes in detail -->

#### Motivation and Context
This pull request introduces a new JWT authenticator specifically for the PagoPA issuer. The new authenticator is necessary to handle sessions and authentication for services that are now using PagoPA as their identity provider.

This feature is crucial for integrating our services with the new Google SSO authentication flow. Without this change, users @pagopa.it would not be able to access our services.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Unit Tests: All new and existing unit tests pass.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.